### PR TITLE
useNativeDriver required to be specified.

### DIFF
--- a/src/components/animatedScanner/index.js
+++ b/src/components/animatedScanner/index.js
@@ -83,7 +83,8 @@ export default class AnimatedScanner extends BaseComponent {
     const {animatedProgress} = this.state;
     Animated.timing(animatedProgress, {
       toValue,
-      duration
+      duration,
+      useNativeDriver: false
     }).start(({finished}) => {
       if (finished) {
         const isDone = toValue >= 100;


### PR DESCRIPTION
For Animated Scanner, there was an Animated method where useNativeDriver was not specified

Also, animating left is not supported natively so, I set useNativeDriver to be false 
<img width="589" alt="Screen Shot 2020-07-05 at 4 26 23 PM" src="https://user-images.githubusercontent.com/2018931/86544605-2ff72f80-bedd-11ea-8bd4-93c97963c757.png">
